### PR TITLE
Remove unnecessary calls

### DIFF
--- a/_posts/2013-01-16-connecting-to-sftp-with-key-file-and-password-using-ssh-net.markdown
+++ b/_posts/2013-01-16-connecting-to-sftp-with-key-file-and-password-using-ssh-net.markdown
@@ -45,10 +45,7 @@ using (var client = new SftpClient(con))
         using (var fs = new FileStream(localPath + file.Name, FileMode.Create))
         {
             client.DownloadFile(file.FullName, fs);
-            fs.Close();
         }
     }
-
-    client.Disconnect();
 }
 ```


### PR DESCRIPTION
`SftpClient` and `FileStream` both implement `IDisposable`, so you don't need to call `fs.Close()` or `client.Disconnect()`. They're both handled by their respective `Dispose()` methods, which get called automatically at the end of their `using` blocks.